### PR TITLE
Fix broken mixin link

### DIFF
--- a/doc/src/sphinx/user-guide/testing/index.rst
+++ b/doc/src/sphinx/user-guide/testing/index.rst
@@ -50,7 +50,7 @@ traits to aid in creating simple and powerful tests.
 For more information on `ScalaTest <http://www.scalatest.org/>`__, see the `ScalaTest User Guide <http://www.scalatest.org/user_guide>`__.
 
 To make use of another ScalaTest test style, such as `FunSpec <http://doc.scalatest.org/3.0.0/#org.scalatest.FunSpec>`__ 
-or others, see `Test Mixins <mixin.html>`__.
+or others, see `Test Mixins <mixins.html>`__.
 
 More Information
 ----------------


### PR DESCRIPTION
Problem

See here, on almost bottom page, on section
```
To make use of another ScalaTest test style, such as FunSpec or others, see Test Mixins.
```

There's link to `Test Mixins`, but the link is broken.

Solution

It's because missing `s` on the `html` link.

Result

The link should be fixed by that.